### PR TITLE
CCOL-393. Add feature for group-specific rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,16 @@
+# 1.9.2-beta (2020-08-27)
+
+* add groupRate config: Allows for seperate grouping of jobs in a single queue to have seperate rate limits (see [changes](https://github.com/wishabi/bullmq/pull/5))
+
+### Flipp-added Features
+
+* add disableAutoRun on the worker ([df24af5](https://github.com/wishabi/bullmq/commit/df24af55e8b3d85f778ccc7be11b5bc45789ebae))
+
+
 # [1.9.1](https://github.com/wishabi/bullmq/compare/master...wishabi:bullmq_for_bullwhip) (2020-08-12)
 
 
-### Features
+### Flipp-added Features
 
 * add disableAutoRun on the worker ([df24af5](https://github.com/wishabi/bullmq/commit/df24af55e8b3d85f778ccc7be11b5bc45789ebae))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,7 @@
 # 1.9.2-beta (2020-08-27)
 
-* add groupRate config: Allows for seperate grouping of jobs in a single queue to have seperate rate limits (see [changes](https://github.com/wishabi/bullmq/pull/5))
-
 ### Flipp-added Features
-
-* add disableAutoRun on the worker ([df24af5](https://github.com/wishabi/bullmq/commit/df24af55e8b3d85f778ccc7be11b5bc45789ebae))
-
+* add groupRate config: Allows for seperate grouping of jobs in a single queue to have seperate rate limits (see [changes](https://github.com/wishabi/bullmq/pull/5))
 
 # [1.9.1](https://github.com/wishabi/bullmq/compare/master...wishabi:bullmq_for_bullwhip) (2020-08-12)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+# Flipp Modifications (see [diff](https://github.com/taskforcesh/bullmq/compare/master...wishabi:master))
+
+* Circle CI config + Flipp Artifactory integration
+* Added `disableAutoRun` setting to Worker
+  * This prevents the Worker object from automatically pulling jobs off the queue as soon as the object is instantiated
+  * Allows us to only pull jobs when necessary (e.g. in flipp-bullwhip, when the /pull_job route is hit)
+* Added `groupRates` rate limiting feature
+  * Allows for seperate grouping of jobs in a single queue to have seperate rate limits
+  * See [here](./docs/gitbook/guide/rate-limiting.md) for more usage info
+
+# Original Repo's README below
+
 <div align="center">
   <br/>
   <img src="https://user-images.githubusercontent.com/95200/64285204-99c04900-cf5b-11e9-925c-4743006ce420.png" width="300" />

--- a/docs/gitbook/guide/rate-limiting.md
+++ b/docs/gitbook/guide/rate-limiting.md
@@ -44,7 +44,7 @@ const worker = new Worker(queueName, async job => {}, {
 The following will configure the rate limits so that jobs are grouped by an attribute `shape`. Each grouping of those jobs will be rate limited seperately. If a particular group has rate defined in `groupRates`, then that will be used. Otherwise, the group will use non-group-specific
 rate limit (set here to 5 per second).
 
-In this example, jobs with a `shape` attribute value of `rectangle` will be limited at 4 jobs/second, where as ones with the value `triangle` will be limited to 3/second. Jobs with a `shape` attribute value of anything else, e.g. `circle` or `square` will use the non-group-specific rate limit of 5 job per second per group.
+In this example, jobs with a `shape` attribute value of `rectangle` will be limited at 4 jobs/second, where as ones with the value `triangle` will be limited to 3/second. Jobs with a `shape` attribute value of anything else, e.g. `circle` or `square` will use the non-group-specific rate limit of 5 jobs per second per group.
 
 ```typescript
 const limiterConfig: RateLimiterOptions = {

--- a/docs/gitbook/guide/rate-limiting.md
+++ b/docs/gitbook/guide/rate-limiting.md
@@ -1,2 +1,75 @@
 # Rate limiting
 
+BullMQ has a few options for rate limiting jobs in a queue.
+
+## 1. Single rate limit for all jobs
+
+The following will configure the rate limits so that only a maximum of 5 jobs are picked up every 1 second:
+
+```typescript
+const worker = new Worker(queueName, async job => {}, {
+    limiter: {
+    max: 5,
+    duration: 1000,
+    },
+});
+```
+
+**NOTE**: If there are multiple workers for a single queue, they all need to share the same rate limiter options for this to work.
+
+## 2. Rate limiting jobs in groups, each group with the same defined limit
+
+The following will configure the rate limits so that jobs are grouped by an attribute `shape`. Each grouping of those jobs will be rate limited seperately, but each group will have the same defined limit of 5 jobs per second:
+
+```typescript
+const limiterConfig: RateLimiterOptions = {
+    max: 5,
+    duration: 1000,
+    groupKey: 'shape',
+};
+
+const rateLimitedQueue = new Queue(queueName, {
+    limiter: limiterConfig,
+});
+
+const worker = new Worker(queueName, async job => {}, {
+    limiter: limiterConfig,
+});
+```
+
+**NOTE**: Both the Queue and Worker(s) for the queue need to share the same rate limiter options for this to work. 
+
+## 3. Rate limiting in groups, each group with a seperately defined limit
+
+The following will configure the rate limits so that jobs are grouped by an attribute `shape`. Each grouping of those jobs will be rate limited seperately. If a particular group has rate defined in `groupRates`, then that will be used. Otherwise, the group will use non-group-specific
+rate limit (set here to 5 per second).
+
+In this example, jobs with a `shape` attribute value of `rectangle` will be limited at 4 jobs/second, where as ones with the value `triangle` will be limited to 3/second. Jobs where a `shape` attribute value of anything else, e.g. `circle` or `square` will use the non-group-specific rate limit of 5 job per second per group.
+
+```typescript
+const limiterConfig: RateLimiterOptions = {
+    max: 5,
+    duration: 1000,
+    groupKey: 'shape',
+    groupRates: {
+        rectangle: {
+            max: 4,
+            duration: 1000,
+        },
+        triangle: {
+            max: 3,
+            duration: 1000,
+        },
+    },
+};
+
+const rateLimitedQueue = new Queue(queueName, {
+    limiter: limiterConfig,
+});
+
+const worker = new Worker(queueName, async job => {}, {
+    limiter: limiterConfig,
+});
+```
+
+**NOTE**: Both the Queue and Worker(s) for the queue need to share the same rate limiter options for this to work. 

--- a/docs/gitbook/guide/rate-limiting.md
+++ b/docs/gitbook/guide/rate-limiting.md
@@ -44,7 +44,7 @@ const worker = new Worker(queueName, async job => {}, {
 The following will configure the rate limits so that jobs are grouped by an attribute `shape`. Each grouping of those jobs will be rate limited seperately. If a particular group has rate defined in `groupRates`, then that will be used. Otherwise, the group will use non-group-specific
 rate limit (set here to 5 per second).
 
-In this example, jobs with a `shape` attribute value of `rectangle` will be limited at 4 jobs/second, where as ones with the value `triangle` will be limited to 3/second. Jobs where a `shape` attribute value of anything else, e.g. `circle` or `square` will use the non-group-specific rate limit of 5 job per second per group.
+In this example, jobs with a `shape` attribute value of `rectangle` will be limited at 4 jobs/second, where as ones with the value `triangle` will be limited to 3/second. Jobs with a `shape` attribute value of anything else, e.g. `circle` or `square` will use the non-group-specific rate limit of 5 job per second per group.
 
 ```typescript
 const limiterConfig: RateLimiterOptions = {

--- a/src/classes/queue-base.ts
+++ b/src/classes/queue-base.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import { QueueBaseOptions } from '../interfaces';
+import { QueueOptions } from '../interfaces';
 import { RedisConnection } from './redis-connection';
 
 export class QueueBase extends EventEmitter {
@@ -8,10 +8,7 @@ export class QueueBase extends EventEmitter {
 
   protected connection: RedisConnection;
 
-  constructor(
-    public readonly name: string,
-    public opts: QueueBaseOptions = {},
-  ) {
+  constructor(public readonly name: string, public opts: QueueOptions = {}) {
     super();
 
     this.opts = {

--- a/src/classes/queue.ts
+++ b/src/classes/queue.ts
@@ -1,15 +1,18 @@
 import { get } from 'lodash';
 import { v4 } from 'uuid';
-import { JobsOptions, QueueOptions, RepeatOptions } from '../interfaces';
+import {
+  JobsOptions,
+  QueueOptions,
+  RateLimiterOptions,
+  RepeatOptions,
+} from '../interfaces';
 import { Job, QueueGetters, Repeat } from './';
 import { Scripts } from './scripts';
 
 export class Queue<T = any> extends QueueGetters {
   token = v4();
   jobsOpts: JobsOptions;
-  limiter: {
-    groupKey: string;
-  } = null;
+  limiter: RateLimiterOptions;
   private _repeat: Repeat;
 
   constructor(name: string, opts?: QueueOptions) {

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -53,6 +53,23 @@ export class Scripts {
       opts.lifo ? 'RPUSH' : 'LPUSH',
     ];
 
+    // If groupKey-specific limiter is defined, pass in the rate limiter options
+    // so the script can store them in Redis. Then moveToActive can look for these
+    // rate values if they exist
+    if (
+      queue.opts &&
+      queue.opts.limiter &&
+      queue.opts.limiter.groupKey &&
+      queue.opts.limiter.groupRates
+    ) {
+      const jobData = JSON.parse(job.data);
+      const groupKey = queue.opts.limiter.groupKey;
+      const groupIdentifier = jobData[groupKey];
+      const rates = queue.opts.limiter.groupRates[groupIdentifier];
+
+      if (rates) args.push(groupIdentifier, rates.max, rates.duration);
+    }
+
     keys = keys.concat(<string[]>args);
     return (<any>client).addJob(keys);
   }

--- a/src/classes/scripts.ts
+++ b/src/classes/scripts.ts
@@ -67,7 +67,7 @@ export class Scripts {
       const groupIdentifier = jobData[groupKey];
       const rates = queue.opts.limiter.groupRates[groupIdentifier];
 
-      if (rates) args.push(groupIdentifier, rates.max, rates.duration);
+      if (rates) args.push(rates.max, rates.duration);
     }
 
     keys = keys.concat(<string[]>args);

--- a/src/commands/addJob-8.lua
+++ b/src/commands/addJob-8.lua
@@ -34,6 +34,9 @@
       ARGV[8]  delayedTimestamp
       ARGV[9]  priority
       ARGV[10] LIFO
+      ARGV[11] Rate limiter group key
+      ARGV[12] Group rate limiter max jobs
+      ARGV[13] Group rate limiter duration
 ]]
 local jobId
 local jobIdKey
@@ -55,6 +58,14 @@ end
 -- Store the job.
 rcall("HMSET", jobIdKey, "name", ARGV[3], "data", ARGV[4], "opts", ARGV[5],
       "timestamp", ARGV[6], "delay", ARGV[7], "priority", ARGV[9])
+
+rcall("SET", ARGV[1] .. "chan-test", 108)
+-- Store the group rate limits if they exist
+if (ARGV[11] and ARGV[12] and ARGV[13]) then
+    local limiterKey = ARGV[1] .. "limiter-rates" .. ":" .. ARGV[11] .. ":"
+    rcall("SET", limiterKey .. "max", ARGV[12])
+    rcall("SET", limiterKey .. "duration", ARGV[13])
+end
 
 -- Check if job is delayed
 local delayedTimestamp = tonumber(ARGV[8])

--- a/src/commands/addJob-8.lua
+++ b/src/commands/addJob-8.lua
@@ -34,9 +34,8 @@
       ARGV[8]  delayedTimestamp
       ARGV[9]  priority
       ARGV[10] LIFO
-      ARGV[11] Rate limiter group key
-      ARGV[12] Group rate limiter max jobs
-      ARGV[13] Group rate limiter duration
+      ARGV[11] Group rate limiter max jobs
+      ARGV[12] Group rate limiter duration
 ]]
 local jobId
 local jobIdKey
@@ -59,13 +58,15 @@ end
 rcall("HMSET", jobIdKey, "name", ARGV[3], "data", ARGV[4], "opts", ARGV[5],
       "timestamp", ARGV[6], "delay", ARGV[7], "priority", ARGV[9])
 
-rcall("SET", ARGV[1] .. "chan-test", 108)
--- TODO: could the group key from the jobId like moveToActive-8.lua does?
 -- Store the group rate limits if they exist
-if (ARGV[11] and ARGV[12] and ARGV[13]) then
-    local limiterKey = ARGV[1] .. "limiter-rates" .. ":" .. ARGV[11] .. ":"
-    rcall("SET", limiterKey .. "max", ARGV[12])
-    rcall("SET", limiterKey .. "duration", ARGV[13])
+local groupKey = string.match(jobId, "[^:]+$")
+local groupMaxJobs = ARGV[11]
+local groupDuration = ARGV[12]
+
+if (groupKey ~= nil and groupMaxJobs and groupDuration) then
+    local limiterKey = ARGV[1] .. "limiter-rates" .. ":" .. groupKey .. ":"
+    rcall("SET", limiterKey .. "max", groupMaxJobs)
+    rcall("SET", limiterKey .. "duration", groupDuration)
 end
 
 -- Check if job is delayed

--- a/src/commands/addJob-8.lua
+++ b/src/commands/addJob-8.lua
@@ -60,6 +60,7 @@ rcall("HMSET", jobIdKey, "name", ARGV[3], "data", ARGV[4], "opts", ARGV[5],
       "timestamp", ARGV[6], "delay", ARGV[7], "priority", ARGV[9])
 
 rcall("SET", ARGV[1] .. "chan-test", 108)
+-- TODO: could the group key from the jobId like moveToActive-8.lua does?
 -- Store the group rate limits if they exist
 if (ARGV[11] and ARGV[12] and ARGV[13]) then
     local limiterKey = ARGV[1] .. "limiter-rates" .. ":" .. ARGV[11] .. ":"

--- a/src/commands/addJob-8.lua
+++ b/src/commands/addJob-8.lua
@@ -64,7 +64,7 @@ local groupMaxJobs = ARGV[11]
 local groupDuration = ARGV[12]
 
 if (groupKey ~= nil and groupMaxJobs and groupDuration) then
-    local limiterKey = ARGV[1] .. "limiter-rates" .. ":" .. groupKey .. ":"
+    local limiterKey = ARGV[1] .. "group-limiter-config" .. ":" .. groupKey .. ":"
     rcall("SET", limiterKey .. "max", groupMaxJobs)
     rcall("SET", limiterKey .. "duration", groupDuration)
 end

--- a/src/commands/moveToActive-8.lua
+++ b/src/commands/moveToActive-8.lua
@@ -59,7 +59,7 @@ if jobId then
         rateLimiterKey = rateLimiterKey .. ":" .. groupKey
 
         -- Retrieve and use group-specific rate limits if they exist
-        local groupRateLimitKey = ARGV[1] .. "limiter-rates" .. ":" .. groupKey .. ":"
+        local groupRateLimitKey = ARGV[1] .. "group-limiter-config" .. ":" .. groupKey .. ":"
         local groupMaxJobs = tonumber(rcall("GET", groupRateLimitKey .. "max"))
         local groupDuration = tonumber(rcall("GET", groupRateLimitKey .. "duration"))
         if groupMaxJobs ~= nil and groupDuration ~= nil then

--- a/src/commands/moveToActive-8.lua
+++ b/src/commands/moveToActive-8.lua
@@ -59,24 +59,12 @@ if jobId then
         rateLimiterKey = rateLimiterKey .. ":" .. groupKey
 
         -- Retrieve and use group-specific rate limits if they exist
-        local ghettoDebugVersion = 105
-        rcall("SET", ARGV[1] .. "debug:before", ghettoDebugVersion)
-
         local groupRateLimitKey = ARGV[1] .. "limiter-rates" .. ":" .. groupKey .. ":"
-        rcall("SET", ARGV[1] .. "debug:key", groupRateLimitKey)
         local groupMaxJobs = tonumber(rcall("GET", groupRateLimitKey .. "max"))
-        rcall("SET", ARGV[1] .. "debug:1", ghettoDebugVersion)
         local groupDuration = tonumber(rcall("GET", groupRateLimitKey .. "duration"))
-        rcall("SET", ARGV[1] .. "debug:2", ghettoDebugVersion)
-
         if groupMaxJobs ~= nil and groupDuration ~= nil then
-          rcall("SET", ARGV[1] .. "debug:not-nil", ghettoDebugVersion)
-          rcall("SET", ARGV[1] .. "debug:groupMaxJobs", tostring(groupMaxJobs))
-          rcall("SET", ARGV[1] .. "debug:groupDuration", tostring(groupDuration))
           maxJobs = groupMaxJobs
           duration = groupDuration
-          rcall("SET", ARGV[1] .. "debug:maxJobs", tostring(maxJobs))
-          rcall("SET", ARGV[1] .. "debug:duration", tostring(duration))
         end
       end
     end

--- a/src/interfaces/queue-options.ts
+++ b/src/interfaces/queue-options.ts
@@ -1,4 +1,4 @@
-import { JobsOptions } from '../interfaces';
+import { JobsOptions, RateLimiterOptions } from '../interfaces';
 
 import { Redis } from 'ioredis';
 import { ConnectionOptions } from './redis-options';
@@ -17,9 +17,7 @@ export interface QueueBaseOptions {
 export interface QueueOptions extends QueueBaseOptions {
   defaultJobOptions?: JobsOptions;
 
-  limiter?: {
-    groupKey: string;
-  };
+  limiter?: RateLimiterOptions;
 
   streams?: {
     events: {

--- a/src/interfaces/rate-limiter-options.ts
+++ b/src/interfaces/rate-limiter-options.ts
@@ -1,3 +1,12 @@
+interface Rate {
+  max: number;
+  duration: number;
+}
+
+export interface GroupRates {
+  [key: string]: Rate;
+}
+
 export interface RateLimiterOptions {
   // Max number of jobs processed
   max: number;
@@ -7,4 +16,7 @@ export interface RateLimiterOptions {
 
   // grouping path key in job data
   groupKey?: string;
+
+  // optional rate limits defined per groupKey
+  groupRates?: GroupRates;
 }

--- a/src/test/test_rate_limiter.ts
+++ b/src/test/test_rate_limiter.ts
@@ -8,6 +8,7 @@ import { after, every, last } from 'lodash';
 import { beforeEach, describe, it } from 'mocha';
 import { v4 } from 'uuid';
 import { removeAllQueueData } from '@src/utils';
+import { RateLimiterOptions } from '@src/interfaces';
 
 describe('Rate Limiter', function() {
   let queue: Queue;
@@ -175,6 +176,123 @@ describe('Rate Limiter', function() {
     }
 
     await running;
+    await rateLimitedQueue.close();
+    await worker.close();
+    await queueScheduler.close();
+  });
+
+  it('should respect separate rate limits by grouping', async function() {
+    this.timeout(20000);
+
+    const numGroups = 3;
+    const numJobsPerGroup = 5;
+    const startTime = Date.now();
+
+    const queueScheduler = new QueueScheduler(queueName);
+    await queueScheduler.waitUntilReady();
+
+    // NOTE:
+    // The groupRates feature is a little weird because Queue and Worker require the same
+    // rate limiter options for it to work.
+    // Its because Queue is used for addJob, which adds the group-specific rate limits
+    // for whatever job we're adding.
+    // However, Worker is used for moveToActive, which technically doesn't need the
+    // separate group rate limits defined because those will have already been in Redis,
+    // but it does need groupKey defined to enable group rate limiting logic, and also
+    // the default max/duration so it can fallback to that if group rate limits aren't
+    // found.
+    const limiterConfig: RateLimiterOptions = {
+      max: 1,
+      duration: 3000, // This default should apply for 'group3' jobs
+      groupKey: 'accountId',
+      groupRates: {
+        group1: {
+          max: 1,
+          duration: 1000,
+        },
+        group2: {
+          max: 1,
+          duration: 2000,
+        },
+      },
+    };
+
+    const rateLimitedQueue = new Queue(queueName, { limiter: limiterConfig });
+
+    const worker = new Worker(queueName, async job => {}, {
+      limiter: limiterConfig,
+    });
+    await worker.waitUntilReady();
+
+    const completed: { [index: string]: number[] } = {};
+
+    const running = new Promise((resolve, reject) => {
+      const afterJobs = after(numGroups * numJobsPerGroup, () => {
+        try {
+          // All jobs should be completed by the time all 'group3' jobs
+          // have been completed, since they use the slowest rate limit
+          // which is the default (1 job per 3 sec)
+          const timeDiff = Date.now() - startTime;
+          expect(timeDiff).to.be.gte((numJobsPerGroup - 1) * 3000);
+          expect(timeDiff).to.be.below(numJobsPerGroup * 3000);
+
+          // Test that the time diff between jobs in their groups respect
+          // the duration that was configured (within a 1-second window)
+          for (const group in completed) {
+            let prevTime = completed[group][0];
+            let lowerBound = 0;
+            let upperBound = 0;
+            if (group == 'group1') {
+              lowerBound = 1000;
+              upperBound = 2000;
+            } else if (group == 'group2') {
+              lowerBound = 2000;
+              upperBound = 3000;
+            } else if (group == 'group3') {
+              lowerBound = 3000;
+              upperBound = 4000;
+            }
+            for (let i = 1; i < completed[group].length; i++) {
+              const diff = completed[group][i] - prevTime;
+              expect(diff).to.be.below(upperBound);
+              expect(diff).to.be.gte(lowerBound);
+              prevTime = completed[group][i];
+            }
+          }
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      });
+
+      queueEvents.on('completed', ({ jobId }) => {
+        const group = last(jobId.split(':'));
+        completed[group] = completed[group] || [];
+        completed[group].push(Date.now());
+
+        afterJobs();
+      });
+
+      queueEvents.on('failed', async err => {
+        await worker.close();
+        reject(err);
+      });
+    });
+
+    for (let group = 0; group < numGroups; group++) {
+      for (let i = 0; i < numJobsPerGroup; i++) {
+        const groupId = `${group + 1}`;
+        await rateLimitedQueue.add('group-specific rate test', {
+          accountId: `group${groupId}`,
+        });
+      }
+    }
+
+    await running;
+
+    const completedCount = await rateLimitedQueue.getCompletedCount();
+    expect(completedCount).to.eq(numJobsPerGroup * numGroups);
+
     await rateLimitedQueue.close();
     await worker.close();
     await queueScheduler.close();

--- a/src/test/test_rate_limiter.ts
+++ b/src/test/test_rate_limiter.ts
@@ -185,6 +185,7 @@ describe('Rate Limiter', function() {
     const numGroups = 3;
     const numJobsPerGroup = 5;
     const startTime = Date.now();
+    const buffer = 10; // Used for time diffs, sometimes things are off by a few ms
 
     const queueScheduler = new QueueScheduler(queueName);
     await queueScheduler.waitUntilReady();
@@ -248,8 +249,8 @@ describe('Rate Limiter', function() {
             }
             for (let i = 1; i < completed[group].length; i++) {
               const diff = completed[group][i] - prevTime;
-              expect(diff).to.be.below(lowerBound + 1000);
-              expect(diff).to.be.gte(lowerBound);
+              expect(diff).to.be.below(lowerBound + 1000 + buffer);
+              expect(diff).to.be.gte(lowerBound - buffer);
               prevTime = completed[group][i];
             }
           }

--- a/src/test/test_rate_limiter.ts
+++ b/src/test/test_rate_limiter.ts
@@ -117,20 +117,18 @@ describe('Rate Limiter', function() {
     const queueScheduler = new QueueScheduler(queueName);
     await queueScheduler.waitUntilReady();
 
+    const limiterConfig: RateLimiterOptions = {
+      max: 1,
+      duration: 1000,
+      groupKey: 'accountId',
+    };
+
     const rateLimitedQueue = new Queue(queueName, {
-      limiter: {
-        max: 1,
-        duration: 1000,
-        groupKey: 'accountId',
-      },
+      limiter: limiterConfig,
     });
 
     const worker = new Worker(queueName, async job => {}, {
-      limiter: {
-        max: 1,
-        duration: 1000,
-        groupKey: 'accountId',
-      },
+      limiter: limiterConfig,
     });
 
     const completed: { [index: string]: number[] } = {};
@@ -241,20 +239,16 @@ describe('Rate Limiter', function() {
           for (const group in completed) {
             let prevTime = completed[group][0];
             let lowerBound = 0;
-            let upperBound = 0;
             if (group == 'group1') {
               lowerBound = 1000;
-              upperBound = 2000;
             } else if (group == 'group2') {
               lowerBound = 2000;
-              upperBound = 3000;
             } else if (group == 'group3') {
               lowerBound = 3000;
-              upperBound = 4000;
             }
             for (let i = 1; i < completed[group].length; i++) {
               const diff = completed[group][i] - prevTime;
-              expect(diff).to.be.below(upperBound);
+              expect(diff).to.be.below(lowerBound + 1000);
               expect(diff).to.be.gte(lowerBound);
               prevTime = completed[group][i];
             }

--- a/src/test/test_rate_limiter.ts
+++ b/src/test/test_rate_limiter.ts
@@ -118,6 +118,8 @@ describe('Rate Limiter', function() {
 
     const rateLimitedQueue = new Queue(queueName, {
       limiter: {
+        max: 1,
+        duration: 1000,
         groupKey: 'accountId',
       },
     });


### PR DESCRIPTION
The overall workflow for this new feature:
* Support group-specific rate limit configs via the groupRate key in Queue and Worker configs
**  Note: This unfortunately needs to be added to both Queue and Worker configs, will explain more below
* Modified addJob to pass in groupRate for the given job's group (if defined), and it will write that config to Redis
* Modified moveToActive to check if a groupRate for the selected job exists in Redis, and to use that if it exists. Otherwise fallback to queue's default rate limit config

Why both Queue and Worker need the configs:
* Technically, Queue only needs groupRate defined, since that is the only thing we write to Redis for addJob
* And technically, Worker only needs the default max and duration defined, as well as groupKey, since the groupRates are read in from Redis, but the defaults are passed into moveToActive from the Worker
* But to avoid confusion, I thought it might make sense to just pass the exact same config to both Queue and Worker, since they're defined in a single place in Bullwhip's case anyway